### PR TITLE
auto-fill the fields to the currently-displayed values

### DIFF
--- a/basic_app.py
+++ b/basic_app.py
@@ -9,8 +9,8 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
 socketio = SocketIO(app)
 
-title = "Title"
-ch_title = "Chinese Title"
+title = ''
+ch_title = ''
 hymn = ''
 book = ''
 verse = ''
@@ -43,7 +43,7 @@ def index():
 
 @app.route('/admin', methods=['GET', 'POST'])
 def admin():
-    return render_template("form.html")
+    return render_template("form.html", titleString=title, chTitleString=ch_title, hymnString=hymn, bookString=book, verseString=verse, overlayString=overlay)
 
 @socketio.on('my broadcast event', namespace='/')
 def test_message(message):

--- a/templates/form.html
+++ b/templates/form.html
@@ -5,7 +5,8 @@
   <script src="//code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js" integrity="sha256-yr4fRk/GU1ehYJPAs8P4JlTgu0Hdsp4ZKrx8bDEDC3I=" crossorigin="anonymous"></script>
     <script type="text/javascript" charset="utf-8">
-        $(document).ready(function(){
+        $(document).ready(function() {
+            autoSelectPreviousBook();
             var iChars = "!@#$%^&*()+=-[]\\\';,./{}|\":<>?";
             var socket = io.connect('http://' + document.domain + ':' + location.port);
             socket.on('refresh', function() {
@@ -17,12 +18,26 @@
             });
             $('form#update').submit(function(event) {
                 socket.emit('my broadcast event', {title: $('#title').val(), ch_title: $('#ch_title').val(), hymn: $('#hymn').val(), book: $('#ddbible option:selected').text(), verse: $('#verse').val()});
+                indicateSent();
                 return false;
             });
         });
+        function autoSelectPreviousBook() {
+            var previousBook = $('#previous-book-selection').val();
+            if (!previousBook) return;
+            $('select#ddbible option:contains("' + previousBook + '")').attr('selected', 'selected');
+        }
+        function indicateSent() {
+            $("input, select").each(function() {
+                $(this).css('background-color', '#c5d7fc');
+            });
+            $('button[type="submit"]').prop('disabled', true);
+            $('button[type="reset"]').prop('disabled', true);
+        }
     </script>
 </head>
 <body>
+  <input id="previous-book-selection" style="position: absolute; visibility: hidden;" value="{{ bookString }}">
   <br>
   <br>
   <br>
@@ -31,19 +46,19 @@
     <form class="ui form" id="update" target="_self" method="post">
       <div class="field">
         <label>English Title:</label>
-        <input type="text" name="title" id="title">
+        <input type="text" name="title" id="title" value="{{ titleString }}">
       </div>
       <div class="field">
         <label>Chinese Title:</label>
-        <input type="text" name="ch_title" id="ch_title">
+        <input type="text" name="ch_title" id="ch_title" value="{{ chTitleString }}">
       </div>
       <div class="field">
         <label>Hymn:</label>
-        <input type="text" name="hymn" id="hymn">
+        <input type="text" name="hymn" id="hymn" value="{{ hymnString }}">
       </div>
       <div class="inline fields">
-        <label>Verse:</label>
-        <select class="ui search dropdown" name="ddbible" id="ddbible">
+        <label>Book:</label>
+        <select class="ui search dropdown four wide field" name="ddbible" id="ddbible">
           <option selected="selected" value=""></option>
           <option value="1">Genesis | 創世記</option>
           <option value="2">Exodus | 出埃及記</option>
@@ -115,9 +130,9 @@
         <div class="three wide field">
           <div class="ui left labeled input">
             <a class="ui right pointing label">
-              Passage
+              Verse:
             </a>
-            <input type="text" name="verse" id="verse">
+            <input type="text" name="verse" id="verse" value="{{ verseString }}">
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What the changes do
After submitting, the form fields auto-fill with the information that was last submitted (including the dropdown). See [demo here](https://drive.google.com/file/d/1D1ztpbSN4LTGCdX3GP_aYLodcAsp06y8/view?usp=sharing).

## Why you might want this
Avoid accidentally deleting the hymns or titles when you update the verses. You don't have to retype everything every time you submit. Just change the fields you want to update.

## PR notes
Let me know if you want to merge into `master` instead of merging into `develop`, and I can create another pull request.

## Extra idea not implemented in this PR
`{{ overlayString }}` could be shown on the admin page for easy reference for whoever's assigned to do A/V.